### PR TITLE
'G_IS_OBJECT (object) failed'

### DIFF
--- a/src/fileChooser.c
+++ b/src/fileChooser.c
@@ -8,9 +8,7 @@ void setActiveFile(GtkWidget *window, GFile *file) {
     gtk_window_set_title(GTK_WINDOW(window), g_file_get_basename(file));
 
     OPEN_FILE_PATH = g_file_get_path(file);
-    
-    // TODO: Find out why this line causes 'g_object_unref: assertion 'G_IS_OBJECT (object)' failed'
-    // when the file comes from the terminal.
+
     g_object_unref(file);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,7 @@ static int onOpen(GApplication *app, GFile **files, int fileCount) {
         exit(EXIT_FAILURE);
     }
 
-    file = g_file_dup( files[0] );
+    file = g_object_ref( files[0] );
     g_application_activate(app);
 
     return EXIT_SUCCESS;

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,7 @@ static int onOpen(GApplication *app, GFile **files, int fileCount) {
         exit(EXIT_FAILURE);
     }
 
-    file = files[0];
+    file = g_file_dup( files[0] );
     g_application_activate(app);
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Aparrently solves the problem with 'G_IS_OBJECT (object) failed' mentioned in [src/fileChooser], line 12.